### PR TITLE
Change implementation of #javascriptOn: on MorphdomOptions to delegate to the options dictionary

### DIFF
--- a/src/JQuery-Morphdom-Core/MorphdomOptions.class.st
+++ b/src/JQuery-Morphdom-Core/MorphdomOptions.class.st
@@ -89,10 +89,10 @@ MorphdomOptions >> initialize [
 ]
 
 { #category : #printing }
-MorphdomOptions >> javascriptOn: aStream [
-	"Generate the JavaScript string of the receiver."
+MorphdomOptions >> javascriptOn: aRenderer [
+	"Generate the JavaScript code from the receiver by delegating to the options dictionary."
 	
-	JSStream encodeDictionary: options on: aStream
+	options javascriptOn: aRenderer
 ]
 
 { #category : #options }


### PR DESCRIPTION
This pull request changes #javascriptOn: on MorphdomOptions to delegate to the options dictionary to take into account the removal of #encodeDictionary:on: for JSStream in [Seaside pull request #1483](https://github.com/SeasideSt/Seaside/pull/1483).